### PR TITLE
Fix compilation on compilers without full C99/C++11 support, fix Lua stack for require("enet")

### DIFF
--- a/enet.c
+++ b/enet.c
@@ -748,5 +748,5 @@ int luaopen_enet(lua_State *l) {
 	lua_setfield(l, LUA_REGISTRYINDEX, "enet_peers");
 
 	luaL_register(l, "enet", enet_funcs);
-	return 0;
+	return 1;
 }


### PR DESCRIPTION
Changes originally made to lua-enet's code used in LÖVE.

https://bitbucket.org/rude/love/commits/fba8eb4af9c84510b0565df2d3813bc65d467354 and https://bitbucket.org/rude/love/commits/75a78aa8a6f3ac8f9cc3a04625a7492db579f835
