### PR TITLE
Fix memory leak in peer_send if sending to non-"connected" peer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
+
+enet2.dll: enet.c
+	gcc -O2 -shared -o $@ $< -lenet -llua51 -lws2_32 -lwinmm
+
 enet.so: enet.c
 	luarocks make --local enet-dev-1.rockspec
-
-enet.dll: enet.c
-	gcc -O2 -shared -o $@ $< -lenet -llua5.1 -lws2_32 -lwinmm
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -271,6 +271,8 @@ packets are guaranteed to arrive, and arrive in the order in which they are sent
 Unsequenced packets are unreliable and have no guarantee on the order they
 arrive. Defaults to reliable.
 
+Returns 0 on success and < 0 on failure.
+
 <a name="peerstate"></a>
 ### `peer:state()`
 

--- a/enet.c
+++ b/enet.c
@@ -713,8 +713,14 @@ static int peer_send(lua_State *l) {
 	ENetPacket *packet = read_packet(l, 2, &channel_id);
 
 	// printf("sending, channel_id=%d\n", channel_id);
-	enet_peer_send(peer, channel_id, packet);
-	return 0;
+	int ret = enet_peer_send(peer, channel_id, packet);
+	if (ret < 0) {
+		enet_packet_destroy(packet);
+	}
+
+	lua_pushinteger(l, ret);
+
+	return 1;
 }
 
 static const struct luaL_Reg enet_funcs [] = {

--- a/enet.c
+++ b/enet.c
@@ -1,17 +1,17 @@
 /**
  *
  * Copyright (C) 2014 by Leaf Corcoran
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -486,6 +486,28 @@ static int host_get_peer(lua_State *l) {
 	return 1;
 }
 
+static int host_send(lua_State* l) {
+	ENetHost *host = check_host(l, 1);
+	if (!host) {
+		return luaL_error(l, "Tried to index a nil host!");
+	}
+
+	ENetAddress address;
+	parse_address(l, luaL_checkstring(l, 2), &address);
+
+	size_t size;
+	const void *data = luaL_checklstring(l, 3, &size);
+
+	ENetBuffer buffer;
+	// Casting away the const here is dangerous, but it seems to work well.
+	buffer.data = (void*)data;
+	buffer.dataLength = size;
+
+	enet_socket_send(host->socket, &address, &buffer, 1);
+
+	return 0;
+}
+
 static int host_gc(lua_State *l) {
 	// We have to manually grab the userdata so that we can set it to NULL.
 	ENetHost** host = luaL_checkudata(l, 1, "enet_host");
@@ -713,14 +735,8 @@ static int peer_send(lua_State *l) {
 	ENetPacket *packet = read_packet(l, 2, &channel_id);
 
 	// printf("sending, channel_id=%d\n", channel_id);
-	int ret = enet_peer_send(peer, channel_id, packet);
-	if (ret < 0) {
-		enet_packet_destroy(packet);
-	}
-
-	lua_pushinteger(l, ret);
-
-	return 1;
+	enet_peer_send(peer, channel_id, packet);
+	return 0;
 }
 
 static const struct luaL_Reg enet_funcs [] = {
@@ -750,6 +766,7 @@ static const struct luaL_Reg enet_host_funcs [] = {
 	{"service_time", host_service_time},
 	{"peer_count", host_peer_count},
 	{"get_peer", host_get_peer},
+	{"send_from_socket", host_send},
 	{NULL, NULL}
 };
 
@@ -778,7 +795,7 @@ static const struct luaL_Reg enet_event_funcs [] = {
 	{NULL, NULL}
 };
 
-int luaopen_enet(lua_State *l) {
+int luaopen_enet2(lua_State *l) {
 	enet_initialize();
 	atexit(enet_deinitialize);
 


### PR DESCRIPTION
If the peer being sent to is not in the "connected" state, enet_peer_send will return -1 and the packet created by read_packet will not be freed. 

I stumbled into this bug while I (__foolishly__) wrote this loop:
```lua
for peerIndex = 1, host:peer_count() do
    local peer = host:get_peer(peerIndex)
    if peer ~= event.peer then
        peer:send(event.data, channel, flag)
    end
end
```

In that way I find the documentation on host:get_peer a little bit confusing: "Returns the **connected** peer at the specified index", because get_peer may very well return non-"connected" peers. Should the documentation be adjusted as well in that regard? 